### PR TITLE
fix: validation should include buffer as acceptable type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dylibso/xtp-bindgen",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0-rc.6",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@extism/js-pdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -116,7 +116,7 @@ function validateArrayItems(arrayItem: XtpItemType | parser.XtpItemType | undefi
 }
 
 function validateTypeAndFormat(type: XtpType, format: XtpFormat | undefined, location: string): void {
-  const validTypes = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
+  const validTypes = ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer'];
   if (!validTypes.includes(type)) {
     throw new ValidationError(`Invalid type '${type}'. Options are: ${validTypes.map(t => `'${t}'`).join(', ')}`, location);
   }


### PR DESCRIPTION
Fix from change in #5 

I have also bumped the `package.json` version if we're good to go and can release this