### PR TITLE
fix: remove simple export in v1 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -47,6 +47,10 @@ export interface Export {
   output?: Parameter;
 }
 
+export function isExport(e: any): e is Export {
+  return !!e.name
+}
+
 // These are the same for now
 export type Import = Export
 

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -47,10 +47,6 @@ export interface Export {
   output?: Parameter;
 }
 
-export function isExport(e: any): e is Export {
-  return parser.isSimpleExport(e) || parser.isComplexExport(e)
-}
-
 // These are the same for now
 export type Import = Export
 
@@ -208,58 +204,51 @@ function normalizeV1Schema(parsed: parser.V1Schema): XtpSchema {
   for (const name in parsed.exports) {
     let ex = parsed.exports[name]
 
-    if (parser.isComplexExport(ex)) {
-      const normEx = ex as Export
-      normEx.name = name
+    const normEx = ex as Export
+    normEx.name = name
 
-      if (ex.input?.$ref) {
-        const path = `#/exports/${name}/input`
+    if (ex.input?.$ref) {
+      const path = `#/exports/${name}/input`
 
-        normalizeProp(
-          normEx.input!,
-          querySchemaRef(schemas, ex.input.$ref, path),
-          path
-        )
-      }
-      if (ex.input?.items?.$ref) {
-        const path = `#/exports/${name}/input/items`
-
-        normalizeProp(
-          normEx.input!.items!,
-          querySchemaRef(schemas, ex.input.items.$ref, path),
-          path
-        )
-      }
-
-      if (ex.output?.$ref) {
-        const path = `#/exports/${name}/output`
-
-        normalizeProp(
-          normEx.output!,
-          querySchemaRef(schemas, ex.output.$ref, path),
-          path
-        )
-      }
-      if (ex.output?.items?.$ref) {
-        const path = `#/exports/${name}/output/items`
-
-        normalizeProp(
-          normEx.output!.items!,
-          querySchemaRef(schemas, ex.output.items.$ref, path),
-          path
-        )
-      }
-
-      validateArrayItems(normEx.input?.items, `#/exports/${name}/input/items`);
-      validateArrayItems(normEx.output?.items, `#/exports/${name}/output/items`);
-
-      exports.push(normEx)
-    } else if (parser.isSimpleExport(ex)) {
-      // it's just a name
-      exports.push({ name })
-    } else {
-      throw new ValidationError("Unable to match export to a simple or a complex export", `#/exports/${name}`);
+      normalizeProp(
+        normEx.input!,
+        querySchemaRef(schemas, ex.input.$ref, path),
+        path
+      )
     }
+    if (ex.input?.items?.$ref) {
+      const path = `#/exports/${name}/input/items`
+
+      normalizeProp(
+        normEx.input!.items!,
+        querySchemaRef(schemas, ex.input.items.$ref, path),
+        path
+      )
+    }
+
+    if (ex.output?.$ref) {
+      const path = `#/exports/${name}/output`
+
+      normalizeProp(
+        normEx.output!,
+        querySchemaRef(schemas, ex.output.$ref, path),
+        path
+      )
+    }
+    if (ex.output?.items?.$ref) {
+      const path = `#/exports/${name}/output/items`
+
+      normalizeProp(
+        normEx.output!.items!,
+        querySchemaRef(schemas, ex.output.items.$ref, path),
+        path
+      )
+    }
+
+    validateArrayItems(normEx.input?.items, `#/exports/${name}/input/items`);
+    validateArrayItems(normEx.output?.items, `#/exports/${name}/output/items`);
+
+    exports.push(normEx)
   }
 
   // denormalize all the imports

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,18 +19,10 @@ type VUnknownSchema = V0Schema | V1Schema
 
 export type Version = 'v0' | 'v1-draft';
 
-export type Export = SimpleExport | ComplexExport;
+export type Export = ComplexExport;
 
 // for now, imports and exports look the same
 export type Import = ComplexExport
-
-export function isComplexExport(exportItem: Export): exportItem is ComplexExport {
-  return typeof exportItem === 'object' && 'description' in exportItem;
-}
-
-export function isSimpleExport(exportItem: Export): exportItem is SimpleExport {
-  return typeof exportItem === 'object';
-}
 
 export type SimpleExport = string;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,14 +19,12 @@ type VUnknownSchema = V0Schema | V1Schema
 
 export type Version = 'v0' | 'v1-draft';
 
-export type Export = ComplexExport;
-
 // for now, imports and exports look the same
-export type Import = ComplexExport
+export type Import = Export
 
 export type SimpleExport = string;
 
-export interface ComplexExport {
+export interface Export {
   name: string;
   description?: string;
   codeSamples?: CodeSample[];


### PR DESCRIPTION
This PR does two things:

1. It fixes an inconsistency between the schema and xtp-bindgen: `description` is no longer required on an export
2. v1 doesn't actually support exports being a string since `exports` is now an map, not an array

This was causing a bug where none of the other properties were respected if `description` isn't defined on an export