### PR TITLE
Refactor Bindgen to simpler form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,25 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dylibso/xtp-bindgen",
-      "version": "1.0.0-rc.6",
+      "version": "1.0.0-rc.11",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@extism/js-pdk": "^1.0.1",
         "@types/jest": "^29.5.12",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.8.1",
         "const": "^1.0.0",
         "esbuild": "^0.17.0",
         "esbuild-plugin-d.ts": "^1.2.3",
         "jest": "^29.0.0",
+        "js-yaml": "^4.1.0",
         "ts-jest": "^29.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -962,6 +965,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1405,13 +1430,19 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
+    },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "22.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
+      "integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1488,13 +1519,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3041,13 +3069,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -3852,9 +3879,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3865,9 +3892,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dylibso/xtp-bindgen",
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.12",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@extism/js-pdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
   "devDependencies": {
     "@extism/js-pdk": "^1.0.1",
     "@types/jest": "^29.5.12",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.8.1",
     "const": "^1.0.0",
     "esbuild": "^0.17.0",
     "esbuild-plugin-d.ts": "^1.2.3",
     "jest": "^29.0.0",
+    "js-yaml": "^4.1.0",
     "ts-jest": "^29.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.6.3"
   },
   "files": [
     "dist"

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,6 @@
-export class ValidationError extends Error {
-    constructor(public message: string, public path: string) {
-        super(message);
-        Object.setPrototypeOf(this, ValidationError.prototype);
-    }
+export class ValidationError {
+  constructor(public message: string, public path: string) {
+    this.message = message
+    this.path = path
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ import {
   XtpSchema,
 } from "./normalizer";
 import { CodeSample } from "./parser";
+import { XtpNormalizedType } from "./types";
 export * from "./normalizer";
+export * from "./types";
 export { ValidationError } from "./common";
 
 export function parse(schema: string) {
@@ -104,9 +106,43 @@ function isPrimitive(p: Property | Parameter): boolean {
   return !!p.$ref.enum || !p.$ref.properties;
 }
 
-function isDateTime(p: Property | Parameter | null): boolean {
-  if (!p) return false;
-  return p.type === "string" && p.format === "date-time";
+export type XtpTyped = { xtpType: XtpNormalizedType } | null;
+
+function isDateTime(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === 'date-time'
+}
+function isBuffer(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "buffer"
+}
+function isObject(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "object"
+}
+function isArray(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "array"
+}
+function isEnum(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "enum"
+}
+function isString(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "string"
+}
+function isInt32(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "int32"
+}
+function isInt64(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "int64"
+}
+function isFloat(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "float"
+}
+function isDouble(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "double"
+}
+function isBoolean(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "boolean"
+}
+function isMap(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "map"
 }
 
 function capitalize(s: string) {
@@ -135,6 +171,17 @@ export const helpers = {
   codeSamples,
   isDateTime,
   isPrimitive,
+  isBuffer,
+  isObject,
+  isEnum,
+  isArray,
+  isString,
+  isInt32,
+  isInt64,
+  isFloat,
+  isDouble,
+  isMap,
+  isBoolean,
   isJsonEncoded,
   isUtf8Encoded,
   capitalize,

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ function isPrimitive(p: Property | Parameter): boolean {
   return !!p.$ref.enum || !p.$ref.properties;
 }
 
-export type XtpTyped = { xtpType: XtpNormalizedType } | null;
+export type XtpTyped = { xtpType: XtpNormalizedType };
 
 function isDateTime(p: XtpTyped): boolean {
   return p?.xtpType?.kind === 'date-time'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -122,7 +122,20 @@ class V1Validator {
     }
 
 
-    if (prop.items) this.validateTypedInterface(prop.items)
+    if (prop.items) {
+      this.validateTypedInterface(prop.items)
+
+      // here we are adding some extra constraints on the value type
+      // we can relax these later when we can ensure we can cast these properly
+      this.location.push('items')
+      if (prop.items.items) {
+        this.recordError("Arrays are currently not supported as element types of arrays")
+      }
+      if (prop.items.additionalProperties) {
+        this.recordError("Maps are currently not supported as element types of arrays")
+      }
+      this.location.pop()
+    }
 
     if (prop.additionalProperties) {
       this.validateTypedInterface(prop.additionalProperties)
@@ -131,12 +144,11 @@ class V1Validator {
       // we can relax these later when we can ensure we can cast these properly
       this.location.push('additionalProperties')
       if (prop.additionalProperties.items) {
-        this.recordError("Arrays are currently not supported for value types of maps")
+        this.recordError("Arrays are currently not supported as value types of maps")
       }
       if (prop.additionalProperties.additionalProperties) {
-        this.recordError("Maps are currently not supported for value types of maps")
+        this.recordError("Maps are currently not supported as value types of maps")
       }
-
       this.location.pop()
     }
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,36 +121,8 @@ class V1Validator {
       }
     }
 
-
-    if (prop.items) {
-      this.validateTypedInterface(prop.items)
-
-      // here we are adding some extra constraints on the value type
-      // we can relax these later when we can ensure we can cast these properly
-      this.location.push('items')
-      if (prop.items.items) {
-        this.recordError("Arrays are currently not supported as element types of arrays")
-      }
-      if (prop.items.additionalProperties) {
-        this.recordError("Maps are currently not supported as element types of arrays")
-      }
-      this.location.pop()
-    }
-
-    if (prop.additionalProperties) {
-      this.validateTypedInterface(prop.additionalProperties)
-
-      // here we are adding some extra constraints on the value type
-      // we can relax these later when we can ensure we can cast these properly
-      this.location.push('additionalProperties')
-      if (prop.additionalProperties.items) {
-        this.recordError("Arrays are currently not supported as value types of maps")
-      }
-      if (prop.additionalProperties.additionalProperties) {
-        this.recordError("Maps are currently not supported as value types of maps")
-      }
-      this.location.pop()
-    }
+    if (prop.items) this.validateTypedInterface(prop.items)
+    if (prop.additionalProperties) this.validateTypedInterface(prop.additionalProperties)
   }
 
   getLocation(): string {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,136 @@
-import { ValidationError } from "./common";
+/**
+ * The parser is responsible for taking a raw JS object
+ * of the XTP Schema and parsing and typing it without transforming
+ * any of the values. It's just mean to give a typed representation
+ * of the raw format.
+ */
+import { ValidationError } from "./common"
+
+export interface ParseResult {
+  doc?: VUnknownSchema;
+  errors?: ValidationError[];
+}
+
+/**
+ * Parses and validates an untyped object into a V*Schema
+ */
+export function parseAny(doc: any): ParseResult {
+  switch (doc.version) {
+    case 'v0':
+      return { doc: doc as V0Schema }
+    case 'v1-draft':
+      const v1Doc = doc as V1Schema
+      const validator = new V1Validator(v1Doc)
+      const errors = validator.validate()
+      return { doc: v1Doc, errors }
+    default:
+      return {
+        errors: [
+          new ValidationError(`version property not valid: ${doc.version}`, "#/version")
+        ]
+      }
+  }
+}
+
+export function isV0Schema(schema?: VUnknownSchema): schema is V0Schema {
+  return schema?.version === 'v0';
+}
+
+export function isV1Schema(schema?: VUnknownSchema): schema is V1Schema {
+  return schema?.version === 'v1-draft';
+}
+
+/**
+ * Validates a V1 document.
+ */
+class V1Validator {
+  errors: ValidationError[]
+  location: string[]
+  doc: any
+
+  constructor(doc: V1Schema) {
+    this.doc = doc as any
+    this.errors = []
+    this.location = ['#']
+  }
+
+  /**
+   * Validate the document and return any errors
+   */
+  validate(): ValidationError[] {
+    this.errors = []
+    this.validateNode(this.doc)
+    return this.errors
+  }
+
+  /**
+   * Recursively walk through the untyped document and validate each node.
+   * This saves us a lot of code but might be a little bit slower.
+   */
+  validateNode(node: any) {
+    this.validateTypedInterface(node)
+    if (node && typeof node === 'object') {
+      // i don't think we need to validate array children
+      if (Array.isArray(node)) return
+
+      for (const key in node) {
+        if (Object.prototype.hasOwnProperty.call(node, key)) {
+          const child = node[key]
+          if (typeof child === 'object') {
+            this.location.push(key)
+            this.validateNode(child);
+            this.location.pop()
+          }
+        }
+      }
+    }
+  }
+
+  recordError(msg: string) {
+    this.errors.push(
+      new ValidationError(msg, this.getLocation())
+    )
+  }
+
+  /**
+   * Validates that a node conforms to the rules of
+   * the XtpTyped interface. Validates what we can't
+   * catch in JSON Schema validation.
+   */
+  validateTypedInterface(prop?: XtpTyped): void {
+    if (!prop || !prop.type) return
+
+    const validTypes = ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer'];
+    if (!validTypes.includes(prop.type)) {
+      this.recordError(`Invalid type '${prop.type}'. Options are: ${validTypes.map(t => `'${t}'`).join(', ')}`)
+    }
+
+    if (!prop.format) {
+      return;
+    }
+
+    let validFormats: XtpFormat[] = [];
+    if (prop.type === 'string') {
+      validFormats = ['date-time', 'byte'];
+    } else if (prop.type === 'number') {
+      validFormats = ['float', 'double'];
+    } else if (prop.type === 'integer') {
+      validFormats = ['int32', 'int64'];
+    }
+
+    if (!validFormats.includes(prop.format)) {
+      this.recordError(`Invalid format ${prop.format} for type ${prop.type}. Valid formats are: ${validFormats.join(', ')}`)
+    }
+
+    if (prop.items) this.validateTypedInterface(prop.items)
+    if (prop.additionalProperties) this.validateTypedInterface(prop.additionalProperties)
+  }
+
+  getLocation(): string {
+    return this.location.join('/')
+  }
+}
+
 
 // Main Schema export interface
 export interface V0Schema {
@@ -14,6 +146,9 @@ export interface V1Schema {
     schemas?: { [name: string]: Schema };
   }
 }
+
+// These are the only types we're interested in discriminating
+export type NodeKind = 'schema' | 'property' | 'parameter' | 'import' | 'export'
 
 type VUnknownSchema = V0Schema | V1Schema
 
@@ -40,71 +175,48 @@ export interface CodeSample {
 
 export type MimeType = 'application/json' | 'text/plain; charset=utf-8' | 'application/x-binary'
 
-export interface Schema {
-  description: string;
-  type?: XtpSchemaType;
-  enum?: string[];
-  properties?: { [name: string]: Property };
-  additionalProperties?: Property;
+export interface Schema extends XtpTyped {
+  description?: string;
   required?: string[];
+  properties?: { [name: string]: Property };
 }
 
-export type XtpSchemaType = 'object' | 'enum' | 'map'
+// TODO this figure out how to split up type again?
+//export type XtpSchemaType = 'object' | 'enum' | 'map'
+
 export type XtpType =
-  'integer' | 'string' | 'number' | 'boolean' | 'object' | 'array' | 'buffer';
+  'integer' | 'string' | 'number' | 'boolean' | 'object' |
+  'array' | 'buffer' | 'object' | 'enum' | 'map';
 export type XtpFormat =
   'int32' | 'int64' | 'float' | 'double' | 'date-time' | 'byte';
 
-export interface XtpItemType {
-  type: XtpType;
-  format?: XtpFormat;
-  // NOTE: needs to be any to satisfy type satisfy
-  // type system in normalizer
-  "$ref"?: any;
-  description?: string;
 
-  // we only support one nested item type for now
-  // type: XtpType | XtpItemType;
+// Shared interface for any place you can
+// define some types inline. Ex: Schema, Property, Parameter
+export interface XtpTyped {
+  type?: XtpType;
+  format?: XtpFormat;
+  items?: XtpTyped;
+  additionalProperties?: Property;
+  nullable?: boolean;
+  enum?: string[];
+  name?: string;
+  //properties?: { [name: string]: Property };
+
+  // NOTE: needs to be any to satisfy type satisfy
+  // type system in normalizer, but is in fact a string at this layer
+  "$ref"?: any;
 }
 
+// A property is a named sub-property of an object
+// It's a mostly type info
+export interface Property extends XtpTyped {
+  description?: string;
+}
+
+// The input and output of boundary functions are Parameters.
+// It's a mostly a Property, but also has a required encoding.
 export interface Parameter extends Property {
   contentType: MimeType;
 }
 
-export interface Property {
-  type: XtpType;
-  items?: XtpItemType;
-  format?: XtpFormat;
-  description?: string;
-  nullable?: boolean;
-
-  // NOTE: needs to be any to satisfy type safity in normalizer
-  "$ref"?: any;
-}
-
-export function parseJson(encoded: string): VUnknownSchema {
-  let parsed: any;
-  try {
-    parsed = JSON.parse(encoded);
-  } catch (e) {
-    throw new ValidationError("Invalid JSON", "#");
-  }
-
-  if (!parsed.version) throw new ValidationError("version property missing", "#");
-  switch (parsed.version) {
-    case 'v0':
-      return parsed as V0Schema;
-    case 'v1-draft':
-      return parsed as V1Schema;
-    default:
-      throw new ValidationError(`version property not valid: ${parsed.version}`, "#/version");
-  }
-}
-
-export function isV0Schema(schema: VUnknownSchema): schema is V0Schema {
-  return schema.version === 'v0';
-}
-
-export function isV1Schema(schema: VUnknownSchema): schema is V1Schema {
-  return schema.version === 'v1-draft';
-}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,6 +9,7 @@ import { ValidationError } from "./common"
 export interface ParseResult {
   doc?: VUnknownSchema;
   errors?: ValidationError[];
+  warnings?: ValidationError[];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,13 +12,11 @@ export type XtpNormalizedKind =
 function cons(t: XtpNormalizedType, opts?: XtpTypeOpts): XtpNormalizedType {
   // default them to false
   t.nullable = (opts?.nullable === undefined) ? false : opts.nullable
-  t.required = (opts?.required === undefined) ? false : opts.required
   return t
 }
 
 export interface XtpTypeOpts {
   nullable?: boolean;
-  required?: boolean;
 }
 
 export interface XtpNormalizedType extends XtpTypeOpts {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,137 @@
+/**
+ * These represent the types in our abstract type system.
+ * We will normalize the raw XTP schema into these recursively defined types.
+ */
+
+export type XtpNormalizedKind =
+  'object' | 'enum' | 'map' | 'array' | 'string' |
+  'int32' | 'int64' | 'float' | 'double' |
+  'boolean' | 'date-time' | 'byte' | 'buffer'
+
+// applies type opts to a type on construction
+function cons(t: XtpNormalizedType, opts?: XtpTypeOpts): XtpNormalizedType {
+  // default them to false
+  t.nullable = (opts?.nullable === undefined) ? false : opts.nullable
+  t.required = (opts?.required === undefined) ? false : opts.required
+  return t
+}
+
+export interface XtpTypeOpts {
+  nullable?: boolean;
+  required?: boolean;
+}
+
+export interface XtpNormalizedType extends XtpTypeOpts {
+  kind: XtpNormalizedKind;
+}
+
+export class StringType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'string';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class Int32Type implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'int32';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class Int64Type implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'int64';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class FloatType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'float';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class DoubleType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'double';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class BooleanType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'boolean';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class ByteType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'byte';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class BufferType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'buffer';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class DateTimeType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'date-time';
+  constructor(opts?: XtpTypeOpts) {
+    cons(this, opts)
+  }
+}
+
+export class ObjectType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'object';
+  name: string;
+  properties: Array<XtpNormalizedType>;
+
+  constructor(name: string, properties: Array<XtpNormalizedType>, opts?: XtpTypeOpts) {
+    this.name = name
+    this.properties = properties
+    cons(this, opts)
+  }
+}
+
+export class MapType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'map';
+  keyType = new StringType(); // strings only for now
+  valueType: XtpNormalizedType;
+
+  constructor(valueType: XtpNormalizedType, opts?: XtpTypeOpts) {
+    this.valueType = valueType
+    cons(this, opts)
+  }
+}
+
+export class EnumType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'enum';
+  name: string;
+  elementType: XtpNormalizedType;
+  values: any[];
+
+  constructor(name: string, elementType: XtpNormalizedType, values: any[], opts?: XtpTypeOpts) {
+    this.name = name
+    this.elementType = elementType
+    this.values = values
+    cons(this, opts)
+  }
+}
+
+export class ArrayType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'array';
+  elementType: XtpNormalizedType;
+
+  constructor(elementType: XtpNormalizedType, opts?: XtpTypeOpts) {
+    this.elementType = elementType
+    cons(this, opts)
+  }
+}
+

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,7 +8,7 @@ const validV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-valid-doc.
 test('parse-v1-document', () => {
   const doc = parse(JSON.stringify(validV1Doc))
 
-  //console.log(JSON.stringify(doc, null, 4))
+  console.log(JSON.stringify(doc, null, 4))
 
   // check top level document is correct
   expect(doc.version).toBe('v1')

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -39,19 +39,16 @@ test('parse-v1-document', () => {
   expect(isString(properties[2])).toBe(true)
   expect(properties[2].required).toBe(false)
   expect(isInt32(properties[3])).toBe(true)
+  expect(properties[3].required).toBe(false)
   expect(isDateTime(properties[4])).toBe(true)
+  expect(properties[4].required).toBe(false)
   expect(isMap(properties[5])).toBe(true)
+  expect(properties[5].required).toBe(false)
   let mType = properties[5].xtpType as MapType
   expect(mType.keyType.kind).toBe('string')
   expect(mType.valueType.kind).toBe('string')
-  expect(isMap(properties[6])).toBe(true)
-  mType = properties[6].xtpType as MapType
-  expect(mType.keyType.kind).toBe('string')
-  expect(mType.valueType.kind).toBe('array')
-  let vType = mType.valueType as ArrayType
-  expect(vType.elementType.nullable).toBe(true)
-  expect(vType.elementType.kind).toBe('date-time')
-  expect(isInt32(properties[7])).toBe(true)
+  expect(isInt32(properties[6])).toBe(true)
+  expect(properties[6].required).toBe(false)
 
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)
@@ -66,8 +63,5 @@ test('parse-v1-document', () => {
   // proves we derferenced it
   expect(exp.input?.$ref?.enum).toStrictEqual(validV1Doc.components.schemas['Fruit'].enum)
   expect(exp.output?.contentType).toBe('application/json')
-
-
-
 })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, helpers, MapType, ArrayType } from '../src/index';
+import { parse, helpers, MapType, ArrayType, DateTimeType } from '../src/index';
 const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isMap } = helpers;
 import * as yaml from 'js-yaml'
 import * as fs from 'fs'
@@ -8,7 +8,7 @@ const validV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-valid-doc.
 test('parse-v1-document', () => {
   const doc = parse(JSON.stringify(validV1Doc))
 
-  console.log(JSON.stringify(doc, null, 4))
+  //console.log(JSON.stringify(doc, null, 4))
 
   // check top level document is correct
   expect(doc.version).toBe('v1')
@@ -49,6 +49,20 @@ test('parse-v1-document', () => {
   expect(mType.valueType.kind).toBe('string')
   expect(isInt32(properties[6])).toBe(true)
   expect(properties[6].required).toBe(false)
+  // Map<string, Map<string, Array<Date | null>>
+  expect(isMap(properties[7])).toBe(true)
+  expect(properties[7].required).toBe(false)
+  mType = properties[7].xtpType as MapType
+  expect(mType.keyType.kind).toBe('string')
+  expect(mType.valueType.kind).toBe('map')
+  mType = mType.valueType as MapType
+  expect(mType.keyType.kind).toBe('string')
+  expect(mType.valueType.kind).toBe('array')
+  let aType = mType.valueType as ArrayType
+  expect(aType.kind).toBe('array')
+  expect(aType.elementType.kind).toBe('date-time')
+  expect(aType.elementType.nullable).toBe(true)
+
 
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -24,6 +24,9 @@ test("parse-invalid-v1-document", () => {
     "#/components/schemas/ComplexObject/properties/aString",
     "#/components/schemas/ComplexObject/properties/anInt",
     "#/components/schemas/ComplexObject/properties/aNonType",
+    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
+    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
+    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties/additionalProperties",
   ])
 })
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -17,6 +17,7 @@ test("parse-invalid-v1-document", () => {
   expect(errors).toBeInstanceOf(Array)
 
   const paths = errors!.map(e => e.path)
+  //console.log(JSON.stringify(errors!, null, 4))
   expect(paths).toStrictEqual([
     "#/exports/invalidFunc1/input",
     "#/exports/invalidFunc1/output",
@@ -27,6 +28,7 @@ test("parse-invalid-v1-document", () => {
     "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
     "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
     "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties/additionalProperties",
+    "#/components/schemas/ComplexObject/properties/anArrayOfMaps/items",
   ])
 })
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -25,10 +25,10 @@ test("parse-invalid-v1-document", () => {
     "#/components/schemas/ComplexObject/properties/aString",
     "#/components/schemas/ComplexObject/properties/anInt",
     "#/components/schemas/ComplexObject/properties/aNonType",
-    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
-    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
-    "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties/additionalProperties",
-    "#/components/schemas/ComplexObject/properties/anArrayOfMaps/items",
+    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
+    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
+    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties/additionalProperties",
+    // "#/components/schemas/ComplexObject/properties/anArrayOfMaps/items",
   ])
 })
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,0 +1,37 @@
+import { parseAny, V1Schema } from '../src/parser';
+import * as yaml from 'js-yaml'
+import * as fs from 'fs'
+
+const invalidV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-doc.yaml', 'utf8'))
+const validV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-valid-doc.yaml', 'utf8'))
+
+test("parse-empty-v1-document", () => {
+  const { errors } = parseAny({})
+  expect(errors).toBeInstanceOf(Array)
+
+  expect(errors![0].path).toEqual("#/version")
+})
+
+test("parse-invalid-v1-document", () => {
+  const { errors } = parseAny(invalidV1Doc)
+  expect(errors).toBeInstanceOf(Array)
+
+  const paths = errors!.map(e => e.path)
+  expect(paths).toStrictEqual([
+    "#/exports/invalidFunc1/input",
+    "#/exports/invalidFunc1/output",
+    "#/components/schemas/ComplexObject/properties/aBoolean",
+    "#/components/schemas/ComplexObject/properties/aString",
+    "#/components/schemas/ComplexObject/properties/anInt",
+    "#/components/schemas/ComplexObject/properties/aNonType",
+  ])
+})
+
+test("parse-valid-v1-document", () => {
+  const { doc, errors } = parseAny(validV1Doc)
+  expect(errors).toStrictEqual([])
+
+  const schema = doc as V1Schema
+
+  expect(schema.version).toEqual('v1-draft')
+})

--- a/tests/schemas/v1-invalid-doc.yaml
+++ b/tests/schemas/v1-invalid-doc.yaml
@@ -39,18 +39,4 @@ components:
         aNonType:
           type: non
           description: an int prop
-        aMapOfMapsOfNullableDateArrays:
-          description: a weird map, it's too deep to cast correctly right now
-          additionalProperties:
-            additionalProperties:
-              items:
-                nullable: true
-                type: string
-                format: date-time
-        anArrayOfMaps:
-          description: an illegal array of maps
-          items:
-            additionalProperties:
-              type: string
-              format: date-time
 

--- a/tests/schemas/v1-invalid-doc.yaml
+++ b/tests/schemas/v1-invalid-doc.yaml
@@ -39,4 +39,12 @@ components:
         aNonType:
           type: non
           description: an int prop
+        aMapOfMapsOfNullableDateArrays:
+          description: a weird map, it's too deep to cast correctly right now
+          additionalProperties:
+            additionalProperties:
+              items:
+                nullable: true
+                type: string
+                format: date-time
 

--- a/tests/schemas/v1-invalid-doc.yaml
+++ b/tests/schemas/v1-invalid-doc.yaml
@@ -1,0 +1,42 @@
+---
+version: v1-draft
+exports:
+  invalidFunc1:
+    description: Has some invalid parameters
+    input:
+      type: buffer
+      format: date-time
+    output:
+      type: string
+      format: float
+components:
+  schemas:
+    GhostGang:
+      description: a set of all the enemies of pac-man
+      enum:
+      - blinky
+      - pinky
+      - inky
+      - clyde
+    ComplexObject:
+      description: a complex json object
+      properties:
+        ghost:
+          "$ref": "#/components/schemas/GhostGang"
+          description: i can override the description for the property here
+        aBoolean:
+          type: boolean
+          format: date-time
+          description: a boolean prop
+        aString:
+          type: string
+          format: int32
+          description: an string prop
+        anInt:
+          type: integer
+          format: date-time
+          description: an int prop
+        aNonType:
+          type: non
+          description: an int prop
+

--- a/tests/schemas/v1-invalid-doc.yaml
+++ b/tests/schemas/v1-invalid-doc.yaml
@@ -47,4 +47,10 @@ components:
                 nullable: true
                 type: string
                 format: date-time
+        anArrayOfMaps:
+          description: an illegal array of maps
+          items:
+            additionalProperties:
+              type: string
+              format: date-time
 

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -94,24 +94,9 @@ components:
           description: a string map
           additionalProperties:
             type: string
-        aMapOfNullableDateArrays:
-          description: a string map
-          additionalProperties:
-            items:
-              nullable: true
-              type: string
-              format: date-time
         anIntRef:
           description: a ref to an int which is weird but whatever!
           $ref: "#/components/schemas/MyInt"
-        aMapOfMapsOfNullableDateArrays:
-          description: a weird map
-          additionalProperties:
-            additionalProperties:
-              items:
-                nullable: true
-                type: string
-                format: date-time
     MyInt:
       description: an int as a schema
       type: integer

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -1,0 +1,121 @@
+---
+version: v1-draft
+exports:
+  voidFunc:
+    description: |
+      This demonstrates how you can create an export with
+      no inputs or outputs.
+  primitiveTypeFunc:
+    description: |
+      This demonstrates how you can accept or return primtive types.
+      This function takes a utf8 string and returns a json encoded boolean
+    input:
+      type: string
+      description: A string passed into plugin input
+      contentType: text/plain; charset=utf-8
+    output:
+      type: boolean
+      description: A boolean encoded as json
+      contentType: application/json
+    codeSamples:
+    - lang: typescript
+      label: |
+        Test if a string has more than one character.
+        Code samples show up in documentation and inline in docstrings
+      source: |
+        function primitiveTypeFunc(input: string): boolean {
+          return input.length > 1
+        }
+  referenceTypeFunc:
+    description: |
+      This demonstrates how you can accept or return references to schema types.
+      And it shows how you can define an enum to be used as a property or input/output.
+    input:
+      contentType: application/json
+      "$ref": "#/components/schemas/Fruit"
+    output:
+      contentType: application/json
+      "$ref": "#/components/schemas/ComplexObject"
+imports:
+  eatAFruit:
+    description: |
+      This is a host function. Right now host functions can only be the type (i64) -> i64.
+      We will support more in the future. Much of the same rules as exports apply.
+    input:
+      contentType: text/plain; charset=utf-8
+      "$ref": "#/components/schemas/Fruit"
+    output:
+      type: boolean
+      description: boolean encoded as json
+      contentType: application/json
+components:
+  schemas:
+    Fruit:
+      description: A set of available fruits you can consume
+      enum:
+      - apple
+      - orange
+      - banana
+      - strawberry
+    GhostGang:
+      description: A set of all the enemies of pac-man
+      enum:
+      - blinky
+      - pinky
+      - inky
+      - clyde
+    ComplexObject:
+      description: A complex json object
+      required:
+        - ghost
+        - aBoolean
+      properties:
+        ghost:
+          "$ref": "#/components/schemas/GhostGang"
+          description: I can override the description for the property here
+        aBoolean:
+          type: boolean
+          description: A boolean prop
+        aString:
+          type: string
+          description: An string prop
+        anInt:
+          type: integer
+          format: int32
+          description: An int prop
+        anOptionalDate:
+          type: string
+          format: date-time
+          description: |-
+            A datetime object, we will automatically serialize and deserialize
+            this for you.
+          nullable: true
+        aMap:
+          description: a string map
+          additionalProperties:
+            type: string
+        aMapOfNullableDateArrays:
+          description: a string map
+          additionalProperties:
+            items:
+              nullable: true
+              type: string
+              format: date-time
+        anIntRef:
+          description: a ref to an int which is weird but whatever!
+          $ref: "#/components/schemas/MyInt"
+        aMapOfMapsOfNullableDateArrays:
+          description: a weird map
+          additionalProperties:
+            additionalProperties:
+              items:
+                nullable: true
+                type: string
+                format: date-time
+    MyInt:
+      description: an int as a schema
+      type: integer
+    MapSchema:
+      additionalProperties:
+        type: string
+

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -97,6 +97,14 @@ components:
         anIntRef:
           description: a ref to an int which is weird but whatever!
           $ref: "#/components/schemas/MyInt"
+        aMapOfMapsOfNullableDateArrays:
+          description: a weird map, it's too deep to cast correctly right now
+          additionalProperties:
+            additionalProperties:
+              items:
+                nullable: true
+                type: string
+                format: date-time
     MyInt:
       description: an int as a schema
       type: integer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "allowSyntheticDefaultImports": true,
     "types": [
       "@extism/js-pdk",
-      "jest"
+      "jest",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
Refactoring the bindgen with the goal of having a simpler IR-like form for types
that makes recursively generating type signatures and code easier.

The end goal is to remove all the hairy type portions of the XTP Schema
document. e.g.:

* type
* format
* items
* $ref
* additionalProperties

and replace with a recursively defined type `XtpNormalizedSchema` (name
will likely change to XtpType). I've kept things backwards compatible by
only adding this type on the property `xtpType`. We should switch
bindgens to use this object then we can remove the other properties.

I also decided to change a little bit about the whole process. e.g.:

* moved validation to the parser level code
* remove circularReference detection and blocking
* added some more tests

In order to think more clearly about the whole process, I took up a moment to
write up what I think the whole flow for schemas should be in terms of validating and compiling:

### Step 0: JSON Schema

First we validate against JSON schema. This should ensure that we can parse the document into typescript types in the next step. It should not allow any extra values or any values outside of the enum ranges. We should be able to do a simple `const doc = rawDoc as V1Schema` in typescript and the doc object should be valid.

### Step 1: Parse and Validate

Here we parse the json or yaml into a raw javascript object and cast it to the V1 or V0 schema type. This gives us a raw, but typed representation of the schema. Here we should do extra conditional validation steps that can’t be done (or are too complex to be done) in the JSON Schema. e.g. validating content-type / type pairs, etc.

### Step 2: Normalize

Here we take the raw parsed types and “normalize” them into a simpler form. We will walk the document and replace all occurrences of $ref, items, additionalProperties, type, and format with a single recursive XtpType.
