### PR TITLE
Handle back-compat untyped object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
+  "version": "1.0.0-rc.13",
   "name": "@dylibso/xtp-bindgen",
-  "version": "1.0.0-rc.12",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -187,7 +187,10 @@ class V1SchemaNormalizer {
     if (s.xtpType) return s.xtpType // no need to recalculate
 
     // we can assume this is an object type
-    if (s.properties && s.properties.length > 0) {
+    // if it has type = 'object' or has properties present
+    if ((s.type && s.type === 'object') ||
+      (s.properties && s.properties.length > 0)) {
+
       const properties: XtpNormalizedType[] = []
       for (const pname in s.properties!) {
         const p = s.properties[pname]

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type XtpNormalizedKind =
   'int32' | 'int64' | 'float' | 'double' |
   'boolean' | 'date-time' | 'byte' | 'buffer'
 
+
 // applies type opts to a type on construction
 function cons(t: XtpNormalizedType, opts?: XtpTypeOpts): XtpNormalizedType {
   // default them to false

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,6 +63,8 @@ test('parse-v1-document', () => {
   expect(aType.elementType.kind).toBe('date-time')
   expect(aType.elementType.nullable).toBe(true)
 
+  // untyped object
+  expect(isObject(properties[8])).toBe(true)
 
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -105,6 +105,9 @@ components:
                 nullable: true
                 type: string
                 format: date-time
+        anUntypedObject:
+          description: An untyped object with no properties
+          type: object
     MyInt:
       description: an int as a schema
       type: integer


### PR DESCRIPTION
Follow up from #18 

handle the untyped object (object with no props) for backwards compat. May want to consider translating this to a map in IR for people in the future.