### PR TITLE
feat: make sure users can define exports/imports/schemas/properties named `format`/`type`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "name": "@dylibso/xtp-bindgen",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,3 +4,15 @@ export class ValidationError {
     this.path = path
   }
 }
+
+declare global {
+  interface Array<T> {
+    none(predicate: (item: T) => boolean): boolean;
+  }
+}
+
+if (!Array.prototype.none) {
+  Array.prototype.none = function<T>(predicate: (item: T) => boolean): boolean {
+    return !this.some(predicate);
+  }
+}

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -286,8 +286,11 @@ export function parseAndNormalizeJson(encoded: string): XtpSchema {
   const { doc, errors } = parser.parseAny(JSON.parse(encoded))
 
   if (errors && errors.length > 0) {
-    console.log(JSON.stringify(errors))
-    throw Error(`Invalid document`)
+    if (errors.length === 1) {
+      throw new NormalizeError(errors[0].message, errors)
+    } else {
+      throw new NormalizeError("Multiple errors parsing schema", errors)
+    }
   }
 
   if (parser.isV0Schema(doc)) {
@@ -295,6 +298,15 @@ export function parseAndNormalizeJson(encoded: string): XtpSchema {
   } else if (parser.isV1Schema(doc)) {
     return normalizeV1Schema(doc)
   } else {
-    throw new Error("Could not normalize unknown version of schema");
+    throw new NormalizeError("Could not normalize unknown version of schema", [{
+      message: "Could not normalize unknown version of schema",
+      path: '#/version',
+    }])
+  }
+}
+
+export class NormalizeError extends Error {
+  constructor(msg: string, public errors: ValidationError[]) {
+    super(msg)
   }
 }

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -289,7 +289,7 @@ export function parseAndNormalizeJson(encoded: string): XtpSchema {
     if (errors.length === 1) {
       throw new NormalizeError(errors[0].message, errors)
     } else {
-      throw new NormalizeError("Multiple errors parsing schema", errors)
+      throw new NormalizeError(`${errors[0].message} (and ${errors.length - 1} other error(s))`, errors)
     }
   }
 

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -108,6 +108,14 @@ components:
         anUntypedObject:
           description: An untyped object with no properties
           type: object
+        type:
+          type: string
+          description: An enum prop
+          enum: [complex, simple]
+        format:
+          type: string
+          description: An enum prop
+          enum: [json, xml]
     MyInt:
       description: an int as a schema
       type: integer


### PR DESCRIPTION
We also now throw `NoramlizeError` that has all of the errors as a property, this is useful for the CLI/schema plugin