### PR TITLE
feat: add more error checks in the normalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "name": "@dylibso/xtp-bindgen",
   "description": "XTP bindgen helper library",
   "main": "dist/index.js",

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -116,12 +116,12 @@ interface CycleDetectionContext {
 }
 
 function detectSchemaRefCycles(
-  schema: Schema, 
-  schemas: SchemaMap, 
+  schema: Schema,
+  schemas: SchemaMap,
   context: CycleDetectionContext
 ): void {
   const schemaName = schema.name;
-  
+
   // If we've seen this schema in current path, we have a cycle
   if (context.stack.has(schemaName)) {
     const cycle = context.path.slice(context.path.indexOf(schemaName));
@@ -186,7 +186,7 @@ function detectSchemaRefCycles(
   // Remove from current path stack
   context.stack.delete(schemaName);
   context.path.pop();
-  
+
   // Mark as fully visited
   context.visited.add(schemaName);
 }
@@ -199,7 +199,7 @@ class V1SchemaNormalizer {
   parsed: parser.V1Schema
   errors: ValidationError[] = []
   location: string[] = ['#']
-  
+
   constructor(parsed: parser.V1Schema) {
     this.parsed = parsed
   }
@@ -215,7 +215,7 @@ class V1SchemaNormalizer {
     if (this.parsed.components?.schemas) {
       this.location.push('components');
       this.location.push('schemas');
-      
+
       for (const name in this.parsed.components.schemas) {
         this.location.push(name);
         const pSchema = this.parsed.components.schemas[name];
@@ -250,10 +250,10 @@ class V1SchemaNormalizer {
         schema.name = name
         schema.properties = properties
         this.schemas[name] = schema
-        
+
         this.location.pop();
       }
-      
+
       this.location.pop();
       this.location.pop();
     }
@@ -315,7 +315,7 @@ class V1SchemaNormalizer {
       this.recordError("Not a valid ref " + ref);
       return null;
     }
-    
+
     const name = parts[3];
     const s = this.schemas[name]
     if (!s) {
@@ -334,6 +334,8 @@ class V1SchemaNormalizer {
     if ((s.type && s.type === 'object') ||
       (s.properties && s.properties.length > 0)) {
 
+      s.type = 'object'
+      
       const properties: XtpNormalizedType[] = []
       if (s.properties) {
         this.location.push('properties');
@@ -348,10 +350,11 @@ class V1SchemaNormalizer {
           this.location.pop();
         }
         this.location.pop();
+        return new ObjectType(s.name || '', properties, s)
+      } else {
+        // untyped object
+        return new ObjectType('', [], s)
       }
-
-      s.type = 'object'
-      return new ObjectType(s.name || '', properties, s)
     }
 
     if (s.$ref) {
@@ -436,12 +439,12 @@ export function parseAndNormalizeJson(encoded: string): XtpSchema {
   assert(errors)
 
   if (parser.isV0Schema(doc)) {
-    const {schema, errors} = normalizeV0Schema(doc)
+    const { schema, errors } = normalizeV0Schema(doc)
     assert(errors)
 
     return schema
   } else if (parser.isV1Schema(doc)) {
-    const {schema, errors} = normalizeV1Schema(doc)
+    const { schema, errors } = normalizeV1Schema(doc)
     assert(errors)
 
     return schema

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -138,6 +138,17 @@ class V1SchemaNormalizer {
         this.location.push(name);
         const pSchema = this.parsed.components.schemas[name];
 
+        // validate that required properties are defined
+        if (pSchema.required) {
+          this.location.push('required');
+          for (const name of pSchema.required) {
+            if (!pSchema.properties?.[name]) {
+              this.recordError(`Property ${name} is required but not defined`);
+            }
+          }
+          this.location.pop();
+        }
+
         // turn any parser.Property map we have into Property[]
         const properties = []
         if (pSchema.properties) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,13 +71,14 @@ class V1Validator {
   validateNode(node: any) {
     const currentPath = this.getLocation()
 
-    // allow defining properties/exports/imports/schemas named `type` or `format`
+    // we want to skip validateTypedInterface for some paths
+    // that represent user-defined maps (i.e the keys are defined by the user)
     const skipPatterns = [
-      /^#\/components\/schemas\/[^/]+\/properties$/,
-      /^#\/components\/schemas$/,
-      /^#\/components$/,
-      /^#\/exports$/,
-      /^#\/imports$/
+      /^#\/components\/schemas\/[^/]+\/properties$/, // allow defining properties named `type` or `format`
+      /^#\/components\/schemas$/, // allow defining schemas named `type` or `format`
+      /^#\/components$/, // reserved for future use
+      /^#\/exports$/, // allow defining exports named `type` or `format`
+      /^#\/imports$/ // allow defining imports named `type` or `format`
     ]
     
     const shouldValidate = skipPatterns.none(pattern => pattern.test(currentPath))

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -118,7 +118,7 @@ class V1Validator {
 
     const validTypes = ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer'];
     if (prop.type && !validTypes.includes(prop.type)) {
-      this.recordError(`Invalid type '${stringify(prop.type)}'. Options are: ${validTypes.map(t => `'${t}'`).join(', ')}`)
+      this.recordError(`Invalid type '${stringify(prop.type)}'. Options are: [${validTypes.map(t => `'${t}'`).join(', ')}]`)
     }
 
     if (prop.format) {
@@ -132,7 +132,7 @@ class V1Validator {
       }
 
       if (!validFormats.includes(prop.format)) {
-        this.recordError(`Invalid format ${stringify(prop.format)} for type ${stringify(prop.type)}. Valid formats are: ${validFormats.join(', ')}`)
+        this.recordError(`Invalid format ${stringify(prop.format)} for type ${stringify(prop.type)}. Valid formats are: [${validFormats.join(', ')}]`)
       }
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, helpers, MapType, ArrayType, DateTimeType } from '../src/index';
+import { parse, helpers, MapType, ArrayType, DateTimeType, NormalizeError } from '../src/index';
 const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isMap } = helpers;
 import * as yaml from 'js-yaml'
 import * as fs from 'fs'
@@ -81,3 +81,80 @@ test('parse-v1-document', () => {
   expect(exp.output?.contentType).toBe('application/json')
 })
 
+test('parse-v1-invalid-document', () => {
+  const invalidV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-doc.yaml', 'utf8'))
+  try {
+    parse(JSON.stringify(invalidV1Doc))
+    expect(true).toBe('should have thrown')
+  } catch (e) {
+    if (e instanceof NormalizeError) {
+
+      const expectedErrors = [
+        {
+          message: 'Invalid format date-time for type buffer. Valid formats are: []',
+          path: '#/exports/invalidFunc1/input'
+        },
+        {
+          message: 'Invalid format float for type string. Valid formats are: [date-time, byte]',
+          path: '#/exports/invalidFunc1/output'
+        },
+        {
+          message: 'Invalid format date-time for type boolean. Valid formats are: []',
+          path: '#/components/schemas/ComplexObject/properties/aBoolean'
+        },
+        {
+          message: 'Invalid format int32 for type string. Valid formats are: [date-time, byte]',
+          path: '#/components/schemas/ComplexObject/properties/aString'
+        },
+        {
+          message: 'Invalid format date-time for type integer. Valid formats are: [int32, int64]',
+          path: '#/components/schemas/ComplexObject/properties/anInt'
+        },
+        {
+          message: "Invalid type 'non'. Options are: ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer']",
+          path: '#/components/schemas/ComplexObject/properties/aNonType'
+        }
+      ]
+
+      expect(e.errors.length).toBe(expectedErrors.length)
+      expect(e.errors).toEqual(expect.arrayContaining(expectedErrors))
+    } else {
+      throw e
+    }
+  }
+})
+
+test('parse-v1-invalid-ref-document', () => {
+  const invalidV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-ref-doc.yaml', 'utf8'))
+  try {
+    parse(JSON.stringify(invalidV1Doc))
+    expect(true).toBe('should have thrown')
+  } catch (e) {
+    if (e instanceof NormalizeError) {
+
+      const expectedErrors = [
+        {
+          message: 'Invalid reference #/components/schemas/NonExistentExportInputRef. Cannot find schema NonExistentExportInputRef. Options are: [ComplexObject]',
+          path: '#/exports/invalidFunc/input/$ref'
+        },
+        {
+          message: 'Invalid reference #/components/schemas/NonExistentImportOutputRef. Cannot find schema NonExistentImportOutputRef. Options are: [ComplexObject]',
+          path: '#/imports/invalidImport/output/$ref'
+        },
+        {
+          message: 'Invalid reference #/components/schemas/NonExistentPropertyRef. Cannot find schema NonExistentPropertyRef. Options are: [ComplexObject]',
+          path: '#/components/schemas/ComplexObject/properties/invalidPropRef/$ref'
+        },
+        {
+          message: 'Not a valid ref some invalid ref',
+          path: '#/exports/invalidFunc/output/$ref'
+        }
+      ]
+
+      expect(e.errors.length).toBe(expectedErrors.length)
+      expect(e.errors).toEqual(expect.arrayContaining(expectedErrors))
+    } else {
+      throw e
+    }
+  }
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -169,6 +169,52 @@ test('parse-v1-cycle-doc', () => {
   }
 })
 
+test('parse-v1-invalid-identifiers-doc', () => {
+  const identifierDoc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-identifier-doc.yaml', 'utf8'))
+
+  try {
+    parse(JSON.stringify(identifierDoc))
+    expect(true).toBe('should have thrown')
+  } catch (e) {
+    const expectedErrors = [
+      {
+        message: 'Invalid identifier: "Ghost)Gang". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/components/schemas/Ghost)Gang'
+      },
+      {
+        message: 'Invalid identifier: "gh ost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/components/schemas/ComplexObject/properties/gh ost'
+      },
+      {
+        message: 'Invalid identifier: "aBoo{lean". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/components/schemas/ComplexObject/properties/aBoo{lean'
+      },
+      {
+        message: 'Invalid identifier: "spooky ghost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/components/schemas/Ghost)Gang/enum'
+      },
+      {
+        message: 'Invalid identifier: "invalid@Func". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/exports/invalid@Func'
+      },
+      {
+        message: 'Invalid identifier: "invalid invalid". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/exports/invalid invalid'
+      },
+      {
+        message: 'Invalid identifier: "referenc/eTypeFunc". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/exports/referenc/eTypeFunc'
+      },
+      {
+        message: 'Invalid identifier: "eatA:Fruit". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        path: '#/imports/eatA:Fruit'
+      }
+    ]
+
+    expectErrors(e, expectedErrors)
+  }
+})
+
 function expectErrors(e: any, expectedErrors: ValidationError[]) {
   if (e instanceof NormalizeError) {
     const sortByPath = (a: ValidationError, b: ValidationError) => a.path.localeCompare(b.path);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { parse, helpers, MapType, ArrayType, DateTimeType, NormalizeError, ValidationError } from '../src/index';
+import { parse, helpers, MapType, ArrayType, NormalizeError, ValidationError, ObjectType } from '../src/index';
 const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isMap } = helpers;
 import * as yaml from 'js-yaml'
 import * as fs from 'fs'
@@ -65,7 +65,8 @@ test('parse-v1-document', () => {
 
   // untyped object
   expect(isObject(properties[8])).toBe(true)
-
+  expect((properties[8].xtpType as ObjectType).name).toBe("")
+  
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)
   expect(properties[0].$ref?.name).toBe('GhostGang')

--- a/tests/schemas/v1-invalid-cycle-doc.yaml
+++ b/tests/schemas/v1-invalid-cycle-doc.yaml
@@ -1,0 +1,23 @@
+---
+version: v1-draft
+exports:
+  export1:
+    description: This is an export
+    input:
+      type: string
+    output:
+      contentType: application/json
+      "$ref": "#/components/schemas/ComplexObject"
+components:
+  schemas:
+    ComplexObject:
+      description: A complex json object
+      properties:
+        cycle:
+          "$ref": "#/components/schemas/AnotherType"
+    AnotherType:
+      description: Another type
+      properties:
+        complexObject:
+          "$ref": "#/components/schemas/ComplexObject"
+

--- a/tests/schemas/v1-invalid-identifier-doc.yaml
+++ b/tests/schemas/v1-invalid-identifier-doc.yaml
@@ -1,0 +1,67 @@
+---
+version: v1-draft
+exports:
+  invalid@Func:
+    description: |
+      This demonstrates how you can create an export with
+      no inputs or outputs.
+  "invalid invalid":
+    description: |
+      This demonstrates how you can accept or return primtive types.
+      This function takes a utf8 string and returns a json encoded boolean
+    input:
+      type: string
+      description: A string passed into plugin input
+      contentType: text/plain; charset=utf-8
+    output:
+      type: boolean
+      description: A boolean encoded as json
+      contentType: application/json
+  referenc/eTypeFunc:
+    description: |
+      This demonstrates how you can accept or return references to schema types.
+      And it shows how you can define an enum to be used as a property or input/output.
+    input:
+      contentType: application/json
+      "$ref": "#/components/schemas/Fruit"
+    output:
+      contentType: application/json
+      "$ref": "#/components/schemas/ComplexObject"
+imports:
+  eatA:Fruit:
+    description: |
+      This is a host function. Right now host functions can only be the type (i64) -> i64.
+      We will support more in the future. Much of the same rules as exports apply.
+    input:
+      contentType: text/plain; charset=utf-8
+      "$ref": "#/components/schemas/Fruit"
+    output:
+      type: boolean
+      description: boolean encoded as json
+      contentType: application/json
+components:
+  schemas:
+    Fruit:
+      description: A set of available fruits you can consume
+      enum:
+      - apple
+      - orange
+      - banana
+      - strawberry
+    Ghost)Gang:
+      description: A set of all the enemies of pac-man
+      enum:
+      - blinky
+      - pinky
+      - inky
+      - clyde
+      - "spooky ghost"
+    ComplexObject:
+      description: A complex json object
+      properties:
+        "gh ost":
+          "$ref": "#/components/schemas/Ghost)Gang"
+          description: I can override the description for the property here
+        aBoo{lean:
+          type: boolean
+          description: A boolean prop

--- a/tests/schemas/v1-invalid-parseable-doc.yaml
+++ b/tests/schemas/v1-invalid-parseable-doc.yaml
@@ -1,0 +1,39 @@
+---
+version: v1-draft
+exports:
+  invalidFunc:
+    description: Has some invalid parameters
+    input:
+      contentType: application/json
+      "$ref": "#/components/schemas/NonExistentExportInputRef"
+    output:
+      contentType: application/json
+      "$ref": "some invalid ref"
+imports:
+  invalidImport:
+    description: |
+      This is a host function. Right now host functions can only be the type (i64) -> i64.
+      We will support more in the future. Much of the same rules as exports apply.
+    input:
+      type: string
+    output:
+      contentType: application/json
+      "$ref": "#/components/schemas/NonExistentImportOutputRef"
+components:
+  schemas:
+    ComplexObject:
+      description: A complex json object
+      required:
+        - ghost
+        - aBoolean
+      properties:
+        invalidPropRef:
+          "$ref": "#/components/schemas/NonExistentPropertyRef"
+        cycle:
+          "$ref": "#/components/schemas/AnotherType"
+    AnotherType:
+      description: Another type
+      properties:
+        complexObject:
+          "$ref": "#/components/schemas/ComplexObject"
+

--- a/tests/schemas/v1-invalid-ref-doc.yaml
+++ b/tests/schemas/v1-invalid-ref-doc.yaml
@@ -25,15 +25,7 @@ components:
       description: A complex json object
       required:
         - ghost
-        - aBoolean
+        - invalidPropRef
       properties:
         invalidPropRef:
           "$ref": "#/components/schemas/NonExistentPropertyRef"
-        cycle:
-          "$ref": "#/components/schemas/AnotherType"
-    AnotherType:
-      description: Another type
-      properties:
-        complexObject:
-          "$ref": "#/components/schemas/ComplexObject"
-

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -116,6 +116,9 @@ components:
           type: string
           description: An enum prop
           enum: [json, xml]
+        ComplexObject:
+          type: string
+          description: this is here to make sure we can have a property with the same name as the schema
     MyInt:
       description: an int as a schema
       type: integer

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -119,6 +119,9 @@ components:
         ComplexObject:
           type: string
           description: this is here to make sure we can have a property with the same name as the schema
+        NameWith$2341:
+          type: string
+          description: A name with a dollar sign
     MyInt:
       description: an int as a schema
       type: integer


### PR DESCRIPTION
- [x] make sure all required properties are actually defined
- [x] make circular references illegal (this blows up `JSON.stringify` even in NodeJS)
- [x] the normalizer returns multiple errors now
- [x] fix: when a property is untyped (`object` with no properties), the xtpType.name is set to the property name.
https://github.com/dylibso/xtp-bindgen/blob/2ec57e59903f740082c239af14628609e554cc8c/tests/index.test.ts#L68
https://github.com/dylibso/xtp-bindgen/blob/2ec57e59903f740082c239af14628609e554cc8c/tests/schemas/v1-valid-doc.yaml#L108-L110
- [x] check for invalid identifiers: exports/imports/schemas/properties/enums
- [x] add more tests