### PR TITLE
feat: split untyped objects from objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,9 @@ function isBuffer(p: XtpTyped): boolean {
 function isObject(p: XtpTyped): boolean {
   return p?.xtpType?.kind === "object"
 }
+function isUntypedObject(p: XtpTyped): boolean {
+  return p?.xtpType?.kind === "jsobject"
+}
 function isArray(p: XtpTyped): boolean {
   return p?.xtpType?.kind === "array"
 }
@@ -173,6 +176,7 @@ export const helpers = {
   isPrimitive,
   isBuffer,
   isObject,
+  isUntypedObject,
   isEnum,
   isArray,
   isString,

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ function isBuffer(p: XtpTyped): boolean {
 function isObject(p: XtpTyped): boolean {
   return p?.xtpType?.kind === "object"
 }
-function isUntypedObject(p: XtpTyped): boolean {
+function isFreeFormObject(p: XtpTyped): boolean {
   return p?.xtpType?.kind === "jsobject"
 }
 function isArray(p: XtpTyped): boolean {
@@ -176,7 +176,7 @@ export const helpers = {
   isPrimitive,
   isBuffer,
   isObject,
-  isUntypedObject,
+  isFreeFormObject,
   isEnum,
   isArray,
   isString,

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -16,6 +16,7 @@ import {
   DoubleType,
   BooleanType,
   BufferType,
+  UntypedObjectType
 } from "./types"
 
 export interface XtpTyped extends parser.XtpTyped {
@@ -338,30 +339,27 @@ class V1SchemaNormalizer {
     if (!s || typeof s !== 'object' || Array.isArray(s)) return undefined
     if (s.xtpType) return s.xtpType
 
-    if ((s.type && s.type === 'object') ||
-      (s.properties && s.properties.length > 0)) {
-
+    if (s.properties && s.properties.length > 0) {
       s.type = 'object'
 
       const properties: XtpNormalizedType[] = []
-      if (s.properties) {
-        for (const pname in s.properties) {
-          const p = s.properties[pname]
+      for (const pname in s.properties) {
+        const p = s.properties[pname]
 
-          const t = this.annotateType(p, [...path, 'properties', p.name ?? pname])
-          if (t) {
-            p.xtpType = t
-            properties.push(t)
-          }
+        const t = this.annotateType(p, [...path, 'properties', p.name ?? pname])
+        if (t) {
+          p.xtpType = t
+          properties.push(t)
         }
-        return new ObjectType(s.name || '', properties, s)
-      } else {
-        // untyped object
-        return new ObjectType('', [], s)
       }
+      return new ObjectType(s.name || '', properties, s)
     }
 
     if (s.$ref) {
+      // don't recurse if the type is known
+      if (s.type) {
+        return undefined
+      }
       let ref = s.$ref
       if (typeof s.$ref === 'string') {
         ref = this.querySchemaRef(s.$ref, [...path, '$ref'])
@@ -415,6 +413,8 @@ class V1SchemaNormalizer {
         if (s.format === 'float') return new FloatType(s)
         // default to double
         return new DoubleType(s)
+      case 'object':
+        return new UntypedObjectType(s)
     }
 
     // if we get this far, we don't know what

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -352,7 +352,7 @@ class V1SchemaNormalizer {
           properties.push(t)
         }
       }
-      return new ObjectType(s.name || '', properties, s)
+      return new ObjectType(s.name!, properties, s)
     }
 
     if (s.$ref) {

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -16,7 +16,7 @@ import {
   DoubleType,
   BooleanType,
   BufferType,
-  UntypedObjectType
+  FreeFormObjectType
 } from "./types"
 
 export interface XtpTyped extends parser.XtpTyped {
@@ -414,7 +414,7 @@ class V1SchemaNormalizer {
         // default to double
         return new DoubleType(s)
       case 'object':
-        return new UntypedObjectType(s)
+        return new FreeFormObjectType(s)
     }
 
     // if we get this far, we don't know what

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -207,7 +207,7 @@ export interface Schema extends XtpTyped {
 
 export type XtpType =
   'integer' | 'string' | 'number' | 'boolean' | 'object' |
-  'array' | 'buffer' | 'enum' | 'map';
+  'array' | 'buffer' | 'enum';
 export type XtpFormat =
   'int32' | 'int64' | 'float' | 'double' | 'date-time' | 'byte';
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -80,7 +80,7 @@ class V1Validator {
       /^#\/exports$/, // allow defining exports named `type` or `format`
       /^#\/imports$/ // allow defining imports named `type` or `format`
     ]
-    
+
     const shouldValidate = skipPatterns.none(pattern => pattern.test(currentPath))
     if (shouldValidate) {
       this.validateTypedInterface(node)
@@ -207,7 +207,7 @@ export interface Schema extends XtpTyped {
 
 export type XtpType =
   'integer' | 'string' | 'number' | 'boolean' | 'object' |
-  'array' | 'buffer' | 'object' | 'enum' | 'map';
+  'array' | 'buffer' | 'enum' | 'map';
 export type XtpFormat =
   'int32' | 'int64' | 'float' | 'double' | 'date-time' | 'byte';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,7 @@ export class ObjectType implements XtpNormalizedType {
   }
 }
 
-export class UntypedObjectType implements XtpNormalizedType {
+export class FreeFormObjectType implements XtpNormalizedType {
   kind: XtpNormalizedKind = 'jsobject';
 
   constructor(opts?: XtpTypeOpts) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,8 @@
 export type XtpNormalizedKind =
   'object' | 'enum' | 'map' | 'array' | 'string' |
   'int32' | 'int64' | 'float' | 'double' |
-  'boolean' | 'date-time' | 'byte' | 'buffer'
+  'boolean' | 'date-time' | 'byte' | 'buffer' |
+  'jsobject'
 
 
 // applies type opts to a type on construction
@@ -95,6 +96,14 @@ export class ObjectType implements XtpNormalizedType {
   constructor(name: string, properties: Array<XtpNormalizedType>, opts?: XtpTypeOpts) {
     this.name = name
     this.properties = properties
+    cons(this, opts)
+  }
+}
+
+export class UntypedObjectType implements XtpNormalizedType {
+  kind: XtpNormalizedKind = 'jsobject';
+
+  constructor(opts?: XtpTypeOpts) {
     cons(this, opts)
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { parse, helpers, MapType, ArrayType, NormalizeError, ValidationError, ObjectType, UntypedObjectType } from '../src/index';
-const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isInt64, isMap, isUntypedObject } = helpers;
+import { parse, helpers, MapType, ArrayType, NormalizeError, ValidationError, ObjectType, FreeFormObjectType } from '../src/index';
+const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isInt64, isMap, isFreeFormObject } = helpers;
 import * as yaml from 'js-yaml'
 import * as fs from 'fs'
 
@@ -64,7 +64,7 @@ test('parse-v1-document', () => {
   expect(aType.elementType.nullable).toBe(true)
 
   // untyped object
-  expect(isUntypedObject(properties[8])).toBe(true)
+  expect(isFreeFormObject(properties[8])).toBe(true)
 
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { parse, helpers, MapType, ArrayType, NormalizeError, ValidationError, ObjectType } from '../src/index';
-const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isInt64, isMap } = helpers;
+import { parse, helpers, MapType, ArrayType, NormalizeError, ValidationError, ObjectType, UntypedObjectType } from '../src/index';
+const { isBoolean, isObject, isString, isEnum, isDateTime, isInt32, isInt64, isMap, isUntypedObject } = helpers;
 import * as yaml from 'js-yaml'
 import * as fs from 'fs'
 
@@ -64,8 +64,7 @@ test('parse-v1-document', () => {
   expect(aType.elementType.nullable).toBe(true)
 
   // untyped object
-  expect(isObject(properties[8])).toBe(true)
-  expect((properties[8].xtpType as ObjectType).name).toBe("")
+  expect(isUntypedObject(properties[8])).toBe(true)
 
   // proves we derferenced it
   expect(properties[0].$ref?.enum).toStrictEqual(validV1Doc.components.schemas['GhostGang'].enum)


### PR DESCRIPTION
Fixes https://github.com/dylibso/xtp/issues/921

This change does not effect the schema, but does require changes in the bindgens.

Unfortunately, this does not add support for typed objects without properties as there doesn't appear to be a way to differentiate from other types due to many other types having an empty properties array.

