### PR TITLE
Adding new validation, refactor of validation

### DIFF
--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -1,0 +1,20 @@
+const KEYWORDS = {
+  python: new Set(["false", "none", "true", "and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"]),
+  go: new Set(["break", "default", "func", "interface", "select", "case", "defer", "go", "map", "struct", "chan", "else", "goto", "package", "switch", "const", "fallthrough", "if", "range", "type", "continue", "for", "import", "return", "var"]),
+  csharp: new Set(["abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while"]),
+  rust: new Set(["as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return", "self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where", "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro", "override", "priv", "try", "typeof", "unsized", "virtual", "yield"]),
+  cpp: new Set(["alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char8_t", "char16_t", "char32_t", "class", "compl", "concept", "const", "consteval", "constexpr", "constinit", "const_cast", "continue", "co_await", "co_return", "co_yield", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"]),
+  zig: new Set(["addrspace", "align", "allowzero", "and", "anyframe", "anytype", "asm", "async", "await", "break", "callconv", "catch", "comptime", "const", "continue", "defer", "else", "enum", "errdefer", "error", "export", "extern", "fn", "for", "if", "inline", "linksection", "noalias", "noinline", "nosuspend", "opaque", "or", "orelse", "packed", "pub", "resume", "return", "struct", "suspend", "switch", "test", "threadlocal", "try", "union", "unreachable", "usingnamespace", "var", "volatile", "while"]),
+}
+
+export function checkForKeyword(name: string): string[] | null {
+  const normalizedName = name.toLowerCase()
+  const langs = []
+  for (const lang in KEYWORDS) {
+    // @ts-ignore
+    if (KEYWORDS[lang].has(normalizedName)) {
+      langs.push(lang)
+    }
+  }
+  return langs.length > 0 ? langs : null
+}

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -291,14 +291,15 @@ class V1SchemaNormalizer {
     if (!s || typeof s !== 'object' || Array.isArray(s)) return undefined
     if (s.xtpType) return s.xtpType
 
+    // This pattern should be validated in the parser
     if (s.type && s.type === 'object' && s.additionalProperties) {
       s.type = 'map'
       const valueType = this.annotateType(s.additionalProperties)
       return valueType ? new MapType(valueType, s) : undefined
     }
 
-    if ((s.type && s.type === 'object')
-      || (s.properties && s.properties.length > 0)) {
+    // if we have properties, we should be able to assume it's an object
+    if (s.properties && s.properties.length > 0) {
       s.type = 'object'
       const properties: XtpNormalizedType[] = []
       for (const pname in s.properties) {
@@ -317,6 +318,7 @@ class V1SchemaNormalizer {
       if (s.type) {
         return undefined
       }
+
       // we're ovewriting this string $ref with the link to the
       // node that we find via query it may or may not have
       // been overwritten already

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -289,11 +289,16 @@ class V1SchemaNormalizer {
     if (!s || typeof s !== 'object' || Array.isArray(s)) return undefined
     if (s.xtpType) return s.xtpType
 
-    if ((s.type && s.type === 'object') ||
-      (s.properties && s.properties.length > 0)) {
+    if (s.type && s.type === 'object' && s.additionalProperties) {
+      s.type = 'map'
+      const valueType = this.annotateType(s.additionalProperties)
+      return valueType ? new MapType(valueType, s) : undefined
+    }
+
+    if ((s.type && s.type === 'object')
+      || (s.properties && s.properties.length > 0)) {
 
       s.type = 'object'
-
       const properties: XtpNormalizedType[] = []
       if (s.properties) {
         for (const pname in s.properties) {
@@ -310,6 +315,7 @@ class V1SchemaNormalizer {
         // untyped object
         return new ObjectType('', [], s)
       }
+
     }
 
     if (s.$ref) {
@@ -332,12 +338,6 @@ class V1SchemaNormalizer {
     if (s.items) {
       const itemType = this.annotateType(s.items)
       return itemType ? new ArrayType(itemType, s) : undefined
-    }
-
-    if (s.additionalProperties) {
-      s.type = 'map'
-      const valueType = this.annotateType(s.additionalProperties)
-      return valueType ? new MapType(valueType, s) : undefined
     }
 
     switch (s.type) {

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -278,7 +278,8 @@ class V1SchemaNormalizer {
     }
   }
 
-  // NOTE: this $ref should already be validated as pointing to a schema in the parser
+  // NOTE: we may want to relax this again so we can keep normalizing
+  // even if a ref is invalid
   querySchemaRef(ref: string): Schema {
     const parts = ref.split('/')
     const name = parts[3]

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,11 +11,11 @@ import { checkForKeyword } from "./keywords";
  * Parses and validates an untyped object into a V*Schema
  */
 export function parseAny(doc: any): VUnknownSchema {
+  doc.errors = []
+  doc.warnings = []
   switch (doc.version) {
     case 'v0':
       const v0Doc = doc as V0Schema
-      v0Doc.errors = []
-      v0Doc.warnings = []
       return v0Doc
     case 'v1-draft':
       const v1Doc = doc as V1Schema
@@ -23,9 +23,9 @@ export function parseAny(doc: any): VUnknownSchema {
       validator.validate()
       return v1Doc
     default:
-      doc.errors = [
+      doc.errors.push(
         new ValidationError(`version property not valid: ${doc.version}`, "#/version")
-      ]
+      )
       return doc
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -194,7 +194,12 @@ class V1Validator {
     }
 
     if (prop.items) this.validateTypedInterface(prop.items)
-    if (prop.additionalProperties) this.validateTypedInterface(prop.additionalProperties)
+    if (prop.additionalProperties) {
+      if (prop.type !== 'object') {
+        this.recordError(`The parent type must be 'object' when using additionalProperties but your type is ${prop.type}`)
+      }
+      this.validateTypedInterface(prop.additionalProperties)
+    }
 
     // if we have a $ref, validate it
     if (prop.$ref) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -119,7 +119,7 @@ test('parse-v1-invalid-document', () => {
         '#/components/schemas/ComplexObject/properties/aString'
       ),
       new ValidationError(
-        'Invalid format date-time for type integer. Valid formats are: [int32, int64]',
+        'Invalid format date-time for type integer. Valid formats are: [uint8, int8, uint16, int16, uint32, int32, uint64, int64]',
         '#/components/schemas/ComplexObject/properties/anInt'
       ),
       new ValidationError(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -222,10 +222,18 @@ test('parse-v1-additional-props-doc', () => {
     expect(true).toBe('should have thrown')
   } catch (e) {
     const expectedErrors = [
-      {
-        message: 'We currently do not support objects with both fixed properties and additionalProperties',
-        path: '#/components/schemas/MixedObject'
-      },
+      new ValidationError(
+        'We currently do not support objects with both fixed properties and additionalProperties',
+        '#/components/schemas/MixedObject'
+      ),
+      new ValidationError(
+        "The parent type must be 'object' when using additionalProperties but your type is undefined",
+        "#/components/schemas/MixedObject",
+      ),
+      new ValidationError(
+        "The parent type must be 'object' when using additionalProperties but your type is string",
+        "#/components/schemas/NonObjectType/properties/myMap",
+      ),
     ]
 
     expectErrors(e, expectedErrors)
@@ -282,7 +290,6 @@ test('parse-v1-invalid-keyword-doc', () => {
 
     expectValidationErrors(doc.warnings, expectedErrors)
   } catch (e) {
-    console.log(e)
     expect(true).toBe('should not have thrown')
   }
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -232,11 +232,69 @@ test('parse-v1-additional-props-doc', () => {
   }
 })
 
+test('parse-v1-invalid-keyword-doc', () => {
+  const invalidV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-keyword-doc.yaml', 'utf8'))
+  try {
+    const doc = parse(JSON.stringify(invalidV1Doc))
+    const expectedErrors = [
+      new ValidationError(
+        "Potentially Invalid identifier: \"Break\". This is a keyword in the following languages and may cause trouble with code generation: python,go,csharp,rust,cpp,zig",
+        "#/components/schemas/Break",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"abstract\". This is a keyword in the following languages and may cause trouble with code generation: csharp,rust",
+        "#/components/schemas/Break/properties/abstract",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"addrspace\". This is a keyword in the following languages and may cause trouble with code generation: zig",
+        "#/components/schemas/Break/properties/addrspace",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"alignas\". This is a keyword in the following languages and may cause trouble with code generation: cpp",
+        "#/components/schemas/Break/properties/alignas",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"and\". This is a keyword in the following languages and may cause trouble with code generation: python,cpp,zig",
+        "#/components/schemas/Break/properties/and",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"as\". This is a keyword in the following languages and may cause trouble with code generation: python,csharp,rust",
+        "#/components/schemas/Break/properties/as",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"interface\". This is a keyword in the following languages and may cause trouble with code generation: go,csharp",
+        "#/components/schemas/Break/properties/interface",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"type\". This is a keyword in the following languages and may cause trouble with code generation: go,rust",
+        "#/components/schemas/Break/properties/type",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"false\". This is a keyword in the following languages and may cause trouble with code generation: python,csharp,rust,cpp",
+        "#/exports/false",
+      ),
+      new ValidationError(
+        "Potentially Invalid identifier: \"true\". This is a keyword in the following languages and may cause trouble with code generation: python,csharp,rust,cpp",
+        "#/imports/true",
+      ),
+    ]
+
+
+    expectValidationErrors(doc.warnings, expectedErrors)
+  } catch (e) {
+    console.log(e)
+    expect(true).toBe('should not have thrown')
+  }
+})
+
+function expectValidationErrors(given: ValidationError[], expected: ValidationError[]) {
+  const sortByPath = (a: ValidationError, b: ValidationError) => a.path.localeCompare(b.path);
+  expect([...given].sort(sortByPath)).toEqual([...expected].sort(sortByPath));
+}
+
 function expectErrors(e: any, expectedErrors: ValidationError[]) {
   if (e instanceof NormalizeError) {
-    const sortByPath = (a: ValidationError, b: ValidationError) => a.path.localeCompare(b.path);
-    expect([...e.errors].sort(sortByPath)).toEqual([...expectedErrors].sort(sortByPath));
-
+    expectValidationErrors(e.errors, expectedErrors)
     return
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -89,30 +89,30 @@ test('parse-v1-invalid-document', () => {
     expect(true).toBe('should have thrown')
   } catch (e) {
     const expectedErrors = [
-      {
-        message: 'Invalid format date-time for type buffer. Valid formats are: []',
-        path: '#/exports/invalidFunc1/input'
-      },
-      {
-        message: 'Invalid format float for type string. Valid formats are: [date-time, byte]',
-        path: '#/exports/invalidFunc1/output'
-      },
-      {
-        message: 'Invalid format date-time for type boolean. Valid formats are: []',
-        path: '#/components/schemas/ComplexObject/properties/aBoolean'
-      },
-      {
-        message: 'Invalid format int32 for type string. Valid formats are: [date-time, byte]',
-        path: '#/components/schemas/ComplexObject/properties/aString'
-      },
-      {
-        message: 'Invalid format date-time for type integer. Valid formats are: [int32, int64]',
-        path: '#/components/schemas/ComplexObject/properties/anInt'
-      },
-      {
-        message: "Invalid type 'non'. Options are: ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer']",
-        path: '#/components/schemas/ComplexObject/properties/aNonType'
-      }
+      new ValidationError(
+        'Invalid format date-time for type buffer. Valid formats are: []',
+        '#/exports/invalidFunc1/input'
+      ),
+      new ValidationError(
+        'Invalid format float for type string. Valid formats are: [date-time, byte]',
+        '#/exports/invalidFunc1/output'
+      ),
+      new ValidationError(
+        'Invalid format date-time for type boolean. Valid formats are: []',
+        '#/components/schemas/ComplexObject/properties/aBoolean'
+      ),
+      new ValidationError(
+        'Invalid format int32 for type string. Valid formats are: [date-time, byte]',
+        '#/components/schemas/ComplexObject/properties/aString'
+      ),
+      new ValidationError(
+        'Invalid format date-time for type integer. Valid formats are: [int32, int64]',
+        '#/components/schemas/ComplexObject/properties/anInt'
+      ),
+      new ValidationError(
+        "Invalid type 'non'. Options are: ['string', 'number', 'integer', 'boolean', 'object', 'array', 'buffer']",
+        '#/components/schemas/ComplexObject/properties/aNonType'
+      ),
     ]
 
     expectErrors(e, expectedErrors)
@@ -126,26 +126,26 @@ test('parse-v1-invalid-ref-document', () => {
     expect(true).toBe('should have thrown')
   } catch (e) {
     const expectedErrors = [
-      {
-        message: 'Invalid reference #/components/schemas/NonExistentExportInputRef. Cannot find schema NonExistentExportInputRef. Options are: [ComplexObject]',
-        path: '#/exports/invalidFunc/input/$ref'
-      },
-      {
-        message: 'Invalid reference #/components/schemas/NonExistentImportOutputRef. Cannot find schema NonExistentImportOutputRef. Options are: [ComplexObject]',
-        path: '#/imports/invalidImport/output/$ref'
-      },
-      {
-        message: 'Invalid reference #/components/schemas/NonExistentPropertyRef. Cannot find schema NonExistentPropertyRef. Options are: [ComplexObject]',
-        path: '#/components/schemas/ComplexObject/properties/invalidPropRef/$ref'
-      },
-      {
-        message: 'Not a valid ref some invalid ref',
-        path: '#/exports/invalidFunc/output/$ref'
-      },
-      {
-        message: "Property ghost is required but not defined",
-        path: "#/components/schemas/ComplexObject/required"
-      }
+      new ValidationError(
+        'Property ghost is marked as required but not defined',
+        '#/components/schemas/ComplexObject'
+      ),
+      new ValidationError(
+        'Invalid $ref "#/components/schemas/NonExistentExportInputRef". Cannot find schema "NonExistentExportInputRef". Options are: [ComplexObject]',
+        '#/exports/invalidFunc/input/$ref'
+      ),
+      new ValidationError(
+        'Invalid $ref "#/components/schemas/NonExistentImportOutputRef". Cannot find schema "NonExistentImportOutputRef". Options are: [ComplexObject]',
+        '#/imports/invalidImport/output/$ref'
+      ),
+      new ValidationError(
+        'Invalid $ref "#/components/schemas/NonExistentPropertyRef". Cannot find schema "NonExistentPropertyRef". Options are: [ComplexObject]',
+        '#/components/schemas/ComplexObject/properties/invalidPropRef/$ref'
+      ),
+      new ValidationError(
+        'Invalid $ref "some invalid ref"',
+        '#/exports/invalidFunc/output/$ref'
+      ),
     ]
 
     expectErrors(e, expectedErrors)
@@ -177,38 +177,38 @@ test('parse-v1-invalid-identifiers-doc', () => {
     expect(true).toBe('should have thrown')
   } catch (e) {
     const expectedErrors = [
-      {
-        message: 'Invalid identifier: "Ghost)Gang". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/components/schemas/Ghost)Gang'
-      },
-      {
-        message: 'Invalid identifier: "gh ost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/components/schemas/ComplexObject/properties/gh ost'
-      },
-      {
-        message: 'Invalid identifier: "aBoo{lean". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/components/schemas/ComplexObject/properties/aBoo{lean'
-      },
-      {
-        message: 'Invalid identifier: "spooky ghost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/components/schemas/Ghost)Gang/enum'
-      },
-      {
-        message: 'Invalid identifier: "invalid@Func". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/exports/invalid@Func'
-      },
-      {
-        message: 'Invalid identifier: "invalid invalid". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/exports/invalid invalid'
-      },
-      {
-        message: 'Invalid identifier: "referenc/eTypeFunc". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/exports/referenc/eTypeFunc'
-      },
-      {
-        message: 'Invalid identifier: "eatA:Fruit". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
-        path: '#/imports/eatA:Fruit'
-      }
+      new ValidationError(
+        'Invalid identifier: "Ghost)Gang". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/components/schemas/Ghost)Gang'
+      ),
+      new ValidationError(
+        'Invalid identifier: "gh ost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/components/schemas/ComplexObject/properties/gh ost'
+      ),
+      new ValidationError(
+        'Invalid identifier: "aBoo{lean". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/components/schemas/ComplexObject/properties/aBoo{lean'
+      ),
+      new ValidationError(
+        'Invalid identifier: "spooky ghost". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/components/schemas/Ghost)Gang/enum'
+      ),
+      new ValidationError(
+        'Invalid identifier: "invalid@Func". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/exports/invalid@Func'
+      ),
+      new ValidationError(
+        'Invalid identifier: "invalid invalid". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/exports/invalid invalid'
+      ),
+      new ValidationError(
+        'Invalid identifier: "referenc/eTypeFunc". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/exports/referenc/eTypeFunc'
+      ),
+      new ValidationError(
+        'Invalid identifier: "eatA:Fruit". Must match /^[a-zA-Z_$][a-zA-Z0-9_$]*$/',
+        '#/imports/eatA:Fruit'
+      ),
     ]
 
     expectErrors(e, expectedErrors)

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -17,7 +17,6 @@ test("parse-invalid-v1-document", () => {
   expect(errors).toBeInstanceOf(Array)
 
   const paths = errors!.map(e => e.path)
-  //console.log(JSON.stringify(errors!, null, 4))
   expect(paths).toStrictEqual([
     "#/exports/invalidFunc1/input",
     "#/exports/invalidFunc1/output",
@@ -25,10 +24,6 @@ test("parse-invalid-v1-document", () => {
     "#/components/schemas/ComplexObject/properties/aString",
     "#/components/schemas/ComplexObject/properties/anInt",
     "#/components/schemas/ComplexObject/properties/aNonType",
-    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
-    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties",
-    // "#/components/schemas/ComplexObject/properties/aMapOfMapsOfNullableDateArrays/additionalProperties/additionalProperties",
-    // "#/components/schemas/ComplexObject/properties/anArrayOfMaps/items",
   ])
 })
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -6,17 +6,17 @@ const invalidV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-invalid-
 const validV1Doc: any = yaml.load(fs.readFileSync('./tests/schemas/v1-valid-doc.yaml', 'utf8'))
 
 test("parse-empty-v1-document", () => {
-  const { errors } = parseAny({})
-  expect(errors).toBeInstanceOf(Array)
+  const doc = parseAny({})
+  expect(doc.errors).toBeInstanceOf(Array)
 
-  expect(errors![0].path).toEqual("#/version")
+  expect(doc.errors![0].path).toEqual("#/version")
 })
 
 test("parse-invalid-v1-document", () => {
-  const { errors } = parseAny(invalidV1Doc)
-  expect(errors).toBeInstanceOf(Array)
+  const doc = parseAny(invalidV1Doc)
+  expect(doc.errors).toBeInstanceOf(Array)
 
-  const paths = errors!.map(e => e.path)
+  const paths = doc.errors!.map(e => e.path)
   expect(paths).toStrictEqual([
     "#/exports/invalidFunc1/input",
     "#/exports/invalidFunc1/output",
@@ -28,8 +28,9 @@ test("parse-invalid-v1-document", () => {
 })
 
 test("parse-valid-v1-document", () => {
-  const { doc, errors } = parseAny(validV1Doc)
-  expect(errors).toStrictEqual([])
+  const doc = parseAny(validV1Doc)
+  expect(doc.errors).toStrictEqual([])
+  expect(doc.warnings).toStrictEqual([])
 
   const schema = doc as V1Schema
 

--- a/tests/schemas/v1-invalid-additional-properties.yaml
+++ b/tests/schemas/v1-invalid-additional-properties.yaml
@@ -4,6 +4,22 @@ exports:
   hello: {}
 components:
   schemas:
+    ValidUse:
+      description: Valid use of additionalProperties
+      properties:
+        myMap:
+          type: object
+          additionalProperties:
+            type: string
+    NonObjectType:
+      description: should not additionalProperties if type !== object
+      properties:
+        hello:
+          type: string
+        myMap:
+          type: string
+          additionalProperties:
+            type: string
     MixedObject:
       description: should not allow mixing fixed and additional props for now
       properties:

--- a/tests/schemas/v1-invalid-additional-properties.yaml
+++ b/tests/schemas/v1-invalid-additional-properties.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:

--- a/tests/schemas/v1-invalid-cycle-doc.yaml
+++ b/tests/schemas/v1-invalid-cycle-doc.yaml
@@ -1,9 +1,11 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:
   export1:
     description: This is an export
     input:
+      contentType: application/json
       type: string
     output:
       contentType: application/json

--- a/tests/schemas/v1-invalid-doc.yaml
+++ b/tests/schemas/v1-invalid-doc.yaml
@@ -1,12 +1,15 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:
   invalidFunc1:
     description: Has some invalid parameters
     input:
+      contentType: application/x-binary
       type: buffer
       format: date-time
     output:
+      contentType: text/plain; charset=utf-8
       type: string
       format: float
 components:

--- a/tests/schemas/v1-invalid-identifier-doc.yaml
+++ b/tests/schemas/v1-invalid-identifier-doc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:

--- a/tests/schemas/v1-invalid-keyword-doc.yaml
+++ b/tests/schemas/v1-invalid-keyword-doc.yaml
@@ -1,0 +1,30 @@
+---
+version: v1-draft
+exports:
+  "false":
+    description: |
+      This demonstrates how you can create an export with
+      no inputs or outputs.
+imports:
+  "true":
+    description: |
+      This is a host function.
+components:
+  schemas:
+    Break:
+      description: A complex json object
+      properties:
+        addrspace:
+          type: string
+        alignas:
+          type: string
+        abstract:
+          type: string
+        as:
+          type: string
+        and:
+          type: string
+        interface:
+          type: string
+        type:
+          type: string

--- a/tests/schemas/v1-invalid-keyword-doc.yaml
+++ b/tests/schemas/v1-invalid-keyword-doc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:

--- a/tests/schemas/v1-invalid-ref-doc.yaml
+++ b/tests/schemas/v1-invalid-ref-doc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:
@@ -15,6 +16,7 @@ imports:
       This is a host function. Right now host functions can only be the type (i64) -> i64.
       We will support more in the future. Much of the same rules as exports apply.
     input:
+      contentType: text/plain; charset=utf-8
       type: string
     output:
       contentType: application/json

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -108,7 +108,7 @@ components:
         anUntypedObject:
           description: An untyped object with no properties
           type: object
-        type:
+        kind:
           type: string
           description: An enum prop
           enum: [complex, simple]

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://xtp.dylibso.com/assets/wasm/schema.json
 ---
 version: v1-draft
 exports:

--- a/tests/schemas/v1-valid-doc.yaml
+++ b/tests/schemas/v1-valid-doc.yaml
@@ -92,6 +92,7 @@ components:
           nullable: true
         aMap:
           description: a string map
+          type: object
           additionalProperties:
             type: string
         anIntRef:
@@ -99,7 +100,9 @@ components:
           $ref: "#/components/schemas/MyInt"
         aMapOfMapsOfNullableDateArrays:
           description: a weird map, it's too deep to cast correctly right now
+          type: object
           additionalProperties:
+            type: object
             additionalProperties:
               items:
                 nullable: true
@@ -126,6 +129,7 @@ components:
       description: an int as a schema
       type: integer
     MapSchema:
+      type: object
       additionalProperties:
         type: string
 


### PR DESCRIPTION
I previously added a validation and couldn't get it to trigger. I
realized that since we're doing 2 passes on validation, some of the
validation I was adding wasn't getting triggered.

Ideally, we parse and validate the document in 1 pass. I've moved all
validation to the parser. This will allow us to move all the defensive
code to the parser as well.

## Specific Changes

* Moved as much validation as possible to parser
* Changed ParseResult interface to be part of the docs so we can chain errors
* Added warnings if you use an identifier that is a language keyword
* Validates that you explicitly set `type === object` when using additionalProperties for a map
